### PR TITLE
Install dotenv for build script

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,24 +2,24 @@ const fs = require('fs');
 const path = require('path');
 require('dotenv').config();
 
-// Read the index.html file
-const indexPath = path.join(__dirname, 'index.html');
-let htmlContent = fs.readFileSync(indexPath, 'utf8');
+// Read the config.js file
+const configPath = path.join(__dirname, 'js', 'config.js');
+let configContent = fs.readFileSync(configPath, 'utf8');
 
 // Replace the placeholder values with actual environment variables
-htmlContent = htmlContent.replace(
+configContent = configContent.replace(
   "window.SUPABASE_URL = 'undefined';",
   `window.SUPABASE_URL = '${process.env.SUPABASE_URL}';`
 );
 
-htmlContent = htmlContent.replace(
+configContent = configContent.replace(
   "window.SUPABASE_ANON_KEY = 'undefined';",
   `window.SUPABASE_ANON_KEY = '${process.env.SUPABASE_ANON_KEY}';`
 );
 
-// Write the updated content back to index.html
-fs.writeFileSync(indexPath, htmlContent);
+// Write the updated content back to config.js
+fs.writeFileSync(configPath, configContent);
 
-console.log('✅ Build complete! Environment variables have been injected into index.html');
+console.log('✅ Build complete! Environment variables have been injected into js/config.js');
 console.log(`   SUPABASE_URL: ${process.env.SUPABASE_URL ? '✓ Set' : '✗ Missing'}`);
 console.log(`   SUPABASE_ANON_KEY: ${process.env.SUPABASE_ANON_KEY ? '✓ Set' : '✗ Missing'}`);

--- a/check-setup.js
+++ b/check-setup.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+
+console.log('🔍 Checking your setup...\n');
+
+// Check if .env file exists
+const envPath = path.join(__dirname, '.env');
+if (fs.existsSync(envPath)) {
+    console.log('✅ .env file exists');
+    
+    // Load and check environment variables
+    require('dotenv').config();
+    
+    if (process.env.SUPABASE_URL) {
+        console.log('✅ SUPABASE_URL is set');
+        console.log(`   URL: ${process.env.SUPABASE_URL}`);
+    } else {
+        console.log('❌ SUPABASE_URL is missing in .env file');
+    }
+    
+    if (process.env.SUPABASE_ANON_KEY) {
+        console.log('✅ SUPABASE_ANON_KEY is set');
+        console.log(`   Key starts with: ${process.env.SUPABASE_ANON_KEY.substring(0, 20)}...`);
+    } else {
+        console.log('❌ SUPABASE_ANON_KEY is missing in .env file');
+    }
+} else {
+    console.log('❌ .env file not found!');
+    console.log('   Please create a .env file with your Supabase credentials');
+}
+
+console.log('\n📝 Your .env file should look like this:');
+console.log('SUPABASE_URL=https://your-project-id.supabase.co');
+console.log('SUPABASE_ANON_KEY=eyJ...your-long-key-here...');

--- a/js/config.js
+++ b/js/config.js
@@ -1,0 +1,10 @@
+// Supabase Configuration
+// These values will be replaced by the build script
+window.SUPABASE_URL = 'undefined';
+window.SUPABASE_ANON_KEY = 'undefined';
+
+// Additional configuration
+window.APP_CONFIG = {
+    environment: 'production',
+    version: '1.0.0'
+};


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Modify build script to inject Supabase credentials into `js/config.js` to fix "supabase is not defined" errors.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous build process attempted to inject Supabase credentials into `index.html`, but the necessary placeholders were absent, and the `js/config.js` file (intended to hold these variables) was missing. This PR creates `js/config.js` and updates `build.js` to correctly inject the credentials there, resolving the `supabase is not defined` errors. A `check-setup.js` utility is also added for easier debugging of `.env` configuration.

---

[Open in Web](https://www.cursor.com/agents?id=bc-c47c8789-0289-4ad8-9add-65a90869849a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-c47c8789-0289-4ad8-9add-65a90869849a)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)